### PR TITLE
Fixes to support viewing on AppleTV via PlexConnect

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -196,7 +196,7 @@ def EpisodeDetail(title, url, thumb, summary, art, wiki_url, cat):
 	furl = BASE_URL + url
 	#Log("url ------------------- " + furl)
 	id = furl.split('id=')[1]
-	url = "http://cdn.einthusan.com/geturl/"+id+"/"+cat+"/Washington%2CDallas%2CLondon%2CToronto%2CSan%2CSydney/ & " + furl
+	url = "http://cdn.einthusan.com/geturl/"+id+"/"+cat+"/Washington%2CDallas%2CLondon%2CToronto%2CSan%2CSydney/+&+" + furl
 	oc = ObjectContainer(title1 = unicode(title), art=art)
 	#jsonOBJ = JSON.ObjectFromURL(wiki_url)['query']['pages']
 	

--- a/Contents/Services/URL/CusEinthusan/ServiceCode.pys
+++ b/Contents/Services/URL/CusEinthusan/ServiceCode.pys
@@ -12,7 +12,7 @@ def NormalizeURL(url):
 def MetadataObjectForURL(url):
 
 	try:
-		url = url.split(' & ')[1]
+		url = url.split('+&+')[1]
 		content = HTML.ElementFromURL(url)
 	except:
 		raise Ex.MediaNotAvailable
@@ -44,7 +44,7 @@ def MetadataObjectForURL(url):
 ####################################################################################################
 def MediaObjectsForURL(url):
 
-	url = url.split(' & ')[0]
+	url = url.split('+&+')[0]
 	return [
 		MediaObject(
 			container = Container.MP4,

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ System Requirements
 		- Samsung Plex App
 		- Android Kit-Kat (Samsung Galaxy S3)
 		- iOS (Apple iPhone6)
+		- AppleTV via [PlexConnect] (https://github.com/iBaa/PlexConnect)
 
 How To Install
 ==============


### PR DESCRIPTION
There were a few adjustments I needed to make to get this to work properly with PlexConnect so I could play videos on non-jailbroken AppleTV 2/ AppleTV 3.
