### PR TITLE
Updated ServiceCode for m3u8 links

### DIFF
--- a/Contents/Code/common.py
+++ b/Contents/Code/common.py
@@ -1,6 +1,6 @@
 ################################################################################
 TITLE = "Einthusan"
-VERSION = '0.05' # Release notation (x.y - where x is major and y is minor)
+VERSION = '0.06' # Release notation (x.y - where x is major and y is minor)
 GITHUB_REPOSITORY = 'coder-alpha/Einthusan.bundle'
 PREFIX = "/video/einthusan"
 ################################################################################

--- a/Contents/Services/URL/CusEinthusan/ServiceCode.pys
+++ b/Contents/Services/URL/CusEinthusan/ServiceCode.pys
@@ -1,101 +1,80 @@
-RE_FILE_URL = Regex("'file': '(http.+?)',?")
-BASE_URL = 'http://www.einthusan.com'
-HTTP.Headers['User-Agent'] = 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:33.0) Gecko/20100101 Firefox/33.0'
-HTTP.Headers['Referer'] = 'http://www.einthusan.com'
-	
-####################################################################################################
-def NormalizeURL(url):
+#!/usr/bin/env python
 
-	return url
+"""Einthusan.com ServiceCode"""
+
+BASE_URL = 'http://einthusan.com'
+USER_AGENT = 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:33.0) Gecko/20100101 Firefox/33.0'
+HTTP.Headers['User-Agent'] = USER_AGENT
+HTTP.Headers['Referer'] = BASE_URL
 
 ####################################################################################################
 def MetadataObjectForURL(url):
 
 	try:
 		url = url.split('+&+')[1]
-		content = HTML.ElementFromURL(url)
+		html = HTML.ElementFromURL(url)
 	except:
 		raise Ex.MediaNotAvailable
 
-	title = content.xpath('//a[@class="movie-title"]/text()')
-
-	if len(title) < 1:
+	# setup title, if none then video offline
+	title = html.xpath('//a[@class="movie-title"]/text()')
+	if not title:
 		raise Ex.MediaNotAvailable
 
-	try:
-		thumb = content.xpath('//a[@class="movie-cover-wrapper"]/img/@src')[0]
-		if not thumb.startswith('http'):
-			thumb = '%s/%s' % (BASE_URL, thumb.split('/',1)[1])
-	except:
-		thumb = content.xpath('//div[@class="video-object-thumb"]/a/@src')[0]
-		if not thumb.startswith('http'):
-			thumb = '%s/%s' % (BASE_URL, thumb.split('/',1)[1])
+	# setup thumb with fallback
+	fallback = 'http://i.imgur.com/75YO83o.jpg'
+	thumb = html.xpath('//a[@class="movie-cover-wrapper"]/img/@src')
+	if not thumb:
+		thumb = html.xpath('//div[@class="video-object-thumb"]/a/@src')
+	thumb = thumb[0] if thumb else fallback
 	# for some strange reason einthusan sometimes uses urls with un-escaped spaces in them
 	thumb = thumb.replace(' ', '%20')
+	if not thumb.startswith('http'):
+		thumb = '{}/{}'.format(BASE_URL, thumb.split('/', 1)[1])
 
-	summary = content.xpath('//div[@class="movie-description"]//p[@class="desc_body"]/text()')[0]
+	# setup summary
+	summary = html.xpath('//div[@class="movie-description"]//p[@class="desc_body"]/text()')
+	summary = summary[0].strip() if summary else None
 
 	return VideoClipObject(
-		title = title[0],
-		summary = summary,
-		thumb = Resource.ContentsOfURLWithFallback(url=thumb)
-	)
+		title=title[0].strip(),
+		summary=summary,
+		thumb=Resource.ContentsOfURLWithFallback([thumb, fallback])
+		)
 
 ####################################################################################################
 def MediaObjectsForURL(url):
 
-	url = url.split('+&+')[0]
 	return [
 		MediaObject(
-			container = Container.MP4,
-			video_codec = VideoCodec.H264,
-			video_resolution = '720',
-			audio_codec = AudioCodec.AAC,
-			audio_channels = 2,
-			optimized_for_streaming = True,
-			parts = [PartObject(key=Callback(PlayVideo, url=url, res='hd'))]
-		),
-		MediaObject(
-			container = Container.MP4,
-			video_codec = VideoCodec.H264,
-			video_resolution = 'sd',
-			audio_codec = AudioCodec.AAC,
-			audio_channels = 2,
-			optimized_for_streaming = True,
-			parts = [PartObject(key=Callback(PlayVideo, url=url, res='sd'))]
-		)
-	]
+			parts=[PartObject(
+				key=HTTPLiveStreamURL(Callback(PlayVideo, url=url))
+				)]
+			)
+		]
 
 ####################################################################################################
 @indirect
-def PlayVideo(url, res, **kwargs):
+def PlayVideo(url, **kwargs):
 
 	try:
-		content = HTTP.Request(url).content
-		if len(content) == 0:
-			if 'bluray' in url:
-				url = url.replace('bluray','hd')
-			else:
-				url = url.replace('hd','bluray')
-			content = HTTP.Request(url).content
+		page = HTTP.Request(url.split('+&+')[0], cacheTime=CACHE_1HOUR).content
 	except:
 		raise Ex.MediaNotAvailable
 
-	video_files = content
-
-	return IndirectResponse(VideoClipObject, key=video_files)
+	return IndirectResponse(VideoClipObject, key=page, http_headers={'User-Agent': USER_AGENT})
 
 ####################################################################################################
 def TestURLs():
 
-	test_urls = []
-	data = HTML.ElementFromURL('%s/movies/' % BASE_URL)
+	test_urls = list()
+	data = HTML.ElementFromURL('{}/movies/'.format(BASE_URL))
 
 	for video in data.xpath('//div[@class="video-listing"]'):
 		link = video.xpath('.//a/@href')[0]
 
 		if not link.startswith('http'):
-			link = '%s/%s' % (BASE_URL, link.split('/',1)[1])
+			link = '{}/{}'.foramt(BASE_URL, link.split('/',1)[1])
 		test_urls.append(link)
 
 		if len(test_urls) > 2:

--- a/Contents/Services/URL/CusEinthusan/ServiceCode.pys
+++ b/Contents/Services/URL/CusEinthusan/ServiceCode.pys
@@ -47,6 +47,7 @@ def MediaObjectsForURL(url):
 
 	return [
 		MediaObject(
+			audio_channels=2,
 			parts=[PartObject(
 				key=HTTPLiveStreamURL(Callback(PlayVideo, url=url))
 				)]
@@ -57,12 +58,17 @@ def MediaObjectsForURL(url):
 @indirect
 def PlayVideo(url, **kwargs):
 
+	# Plex transcoder will % encode user-agent causing the request to fail,
+	# No user-agent error when stream can be direct played
+	# Note: user-agent needs to be the same in the request and the VideoClipObject
+	#   because there is a hash tied to the requested user-agent
+	http_headers = {'User-Agent': USER_AGENT.split()[0]}
 	try:
-		page = HTTP.Request(url.split('+&+')[0]).content
+		page = HTTP.Request(url.split('+&+')[0], headers=http_headers, cacheTime=10).content
 	except:
 		raise Ex.MediaNotAvailable
 
-	return IndirectResponse(VideoClipObject, key=page, http_headers={'User-Agent': USER_AGENT})
+	return IndirectResponse(VideoClipObject, key=page.strip(), http_headers=http_headers)
 
 ####################################################################################################
 def TestURLs():

--- a/Contents/Services/URL/CusEinthusan/ServiceCode.pys
+++ b/Contents/Services/URL/CusEinthusan/ServiceCode.pys
@@ -58,7 +58,7 @@ def MediaObjectsForURL(url):
 def PlayVideo(url, **kwargs):
 
 	try:
-		page = HTTP.Request(url.split('+&+')[0], cacheTime=CACHE_1HOUR).content
+		page = HTTP.Request(url.split('+&+')[0]).content
 	except:
 		raise Ex.MediaNotAvailable
 


### PR DESCRIPTION
_(08/11/2016)_

Did little testing so not sure if all links are now `m3u8`, but the few I did test were solely `m3u8` links.  Also cleaned up some of the `MetadataObjectForURL()` code.

Cheers
